### PR TITLE
Fix libstdc++ linkage issue with gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ target_include_directories (
         PRIVATE    "lib/cxx_argp"
         PRIVATE    "${ARGP_INCLUDE_PATH}" )
 target_link_libraries (
-  bF    PRIVATE    "${ARGP_LIBRARIES}"
+  bF    PRIVATE    "-lstdc++" 
+        PRIVATE    "${ARGP_LIBRARIES}"
         PRIVATE    fmt::fmt-header-only )
 
 # add custom option-based flags


### PR DESCRIPTION
Well.. seems like adding -lstdc++ to linker flags was a good idea after all. Apparently clang links with it regardless of you specify it or not, but gcc does not do that by default.